### PR TITLE
Add module specific flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 # Stored data
 data/
 
+# Misc.
+.DS_Store
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/Makefile
+++ b/Makefile
@@ -13,3 +13,15 @@ test-and-fail:
 .PHONY: lint
 lint:
 	pylint ./apis/* ./models/* ./test/* ./visualizations/*
+
+.PHONY: api
+api:
+	python ./ --api
+
+.PHONY: parse-data
+parse-data:
+	python ./ --parse-data
+
+.PHONY:visualize
+visualize:
+	python ./ --visualize

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ A capstone project for UChicago's CAPP122 where abortion related data is taken f
 ## Standard Commands
 - `make format`: Formats the python files within the project using the Python formatter [Black](https://github.com/psf/black)
 - `make test`: Runs test cases in the `test` directory
+- `make api`: Runs the `api` portion of the codebase
+- `make parse-data`: Parses the data output of the `api` layer
+- `make visualize`: Takes the data produced from the `parse-data` layer and creates the project's visualizations
 
 ## How do we run this thing?
 1. After you have installed [Poetry](https://python-poetry.org/docs/basic-usage/), run the command: `poetry shell`

--- a/__main__.py
+++ b/__main__.py
@@ -1,2 +1,25 @@
+import argparse
+
 if __name__ == "__main__":
-    print("oh, what up?")
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("--api", help="Get data from API", type=bool,
+                        default=False, action=argparse.BooleanOptionalAction)
+    parser.add_argument("--parse-data",
+                        help="Parse data from the API and external sources",
+                        type=bool, default=False,
+                        action=argparse.BooleanOptionalAction)
+    parser.add_argument("--visualize", help="Use data from the ",
+                        type=bool, default=False,
+                        action=argparse.BooleanOptionalAction)
+
+    args = parser.parse_args()
+
+    if args.api:
+        print("We are gonna do some API work")
+
+    if args.parse_data:
+        print("We are gonna do some data parsing work")
+
+    if args.visualize:
+        print("We are gonna do some visualizations")

--- a/apis/abortion_policy_api.py
+++ b/apis/abortion_policy_api.py
@@ -4,8 +4,8 @@ import requests
 import os
 import json
 
-APIKEY = os.environ.get('ABORTION_POLICY_API_KEY')
-HEADERS = {'token': APIKEY}
+APIKEY = os.environ.get("ABORTION_POLICY_API_KEY")
+HEADERS = {"token": APIKEY}
 
 
 def get_states(filepath):
@@ -35,10 +35,14 @@ def get_state_data():
     """
 
     # URLS for API data
-    gestational_limits_url = 'http://api.abortionpolicyapi.com/v1/gestational_limits/states'
-    insurance_coverage_url = 'http://api.abortionpolicyapi.com/v1/insurance_coverage/states/'
-    minors_url = 'http://api.abortionpolicyapi.com/v1/minors/states/'
-    waiting_periods_url = 'http://api.abortionpolicyapi.com/v1/waiting_periods/states/'
+    gestational_limits_url = (
+        "http://api.abortionpolicyapi.com/v1/gestational_limits/states"
+    )
+    insurance_coverage_url = (
+        "http://api.abortionpolicyapi.com/v1/insurance_coverage/states/"
+    )
+    minors_url = "http://api.abortionpolicyapi.com/v1/minors/states/"
+    waiting_periods_url = "http://api.abortionpolicyapi.com/v1/waiting_periods/states/"
 
     r_gestational = requests.get(gestational_limits_url, headers=HEADERS)
     r_insurance = requests.get(insurance_coverage_url, headers=HEADERS)

--- a/apis/abortion_policy_api.py
+++ b/apis/abortion_policy_api.py
@@ -27,8 +27,8 @@ def get_states(filepath):
 
 def get_state_data():
     """
-    Return state policy data for: gestational limits, insurance coverage, minors,
-        and waiting periods
+    Return state policy data for: gestational limits, insurance coverage,
+        minors, and waiting periods
 
     Returns:
         (tuple) tuple of dictionaries for each state and policy type
@@ -42,7 +42,8 @@ def get_state_data():
         "http://api.abortionpolicyapi.com/v1/insurance_coverage/states/"
     )
     minors_url = "http://api.abortionpolicyapi.com/v1/minors/states/"
-    waiting_periods_url = "http://api.abortionpolicyapi.com/v1/waiting_periods/states/"
+    waiting_periods_url = \
+        "http://api.abortionpolicyapi.com/v1/waiting_periods/states/"
 
     r_gestational = requests.get(gestational_limits_url, headers=HEADERS)
     r_insurance = requests.get(insurance_coverage_url, headers=HEADERS)

--- a/pylintrc
+++ b/pylintrc
@@ -280,7 +280,7 @@ max-module-lines=99999
 # spaces.  Google's externaly-published style guide says 4, consistent with
 # PEP 8.  Here, we use 2 spaces, for conformity with many open-sourced Google
 # projects (like TensorFlow).
-indent-string='  '
+indent-string='    '
 
 # Number of spaces of indent required inside a hanging  or continued line.
 indent-after-paren=4

--- a/pylintrc
+++ b/pylintrc
@@ -277,9 +277,8 @@ single-line-if-stmt=yes
 max-module-lines=99999
 
 # String used as indentation unit.  The internal Google style guide mandates 2
-# spaces.  Google's externaly-published style guide says 4, consistent with
-# PEP 8.  Here, we use 2 spaces, for conformity with many open-sourced Google
-# projects (like TensorFlow).
+# spaces.  Google's externally-published style guide says 4, consistent with
+# PEP 8.
 indent-string='    '
 
 # Number of spaces of indent required inside a hanging  or continued line.


### PR DESCRIPTION
## What does this pull request add?
It adds module specific flags and then adds commands to the `Makefile` so that we can run individual parts of the application from there as well.

## Are there any technical things that should be noted for this PR?
I ran  `make format` and there were some leftovers from the last PR. @chanteriam, could you address the `lint` things in another PR?

## How was it tested?
- [x] Ran `make lint` and `make format`
- [x] Manual testing of command line flags

```
(reproductive-rights-data-project-py3.11) michaelp@MacBook-Air-3 reproductive-rights-data-project % python ./ --api
We are gonna do some API work
(reproductive-rights-data-project-py3.11) michaelp@MacBook-Air-3 reproductive-rights-data-project % python ./ --api --parse-data
We are gonna do some API work
We are gonna do some data parsing work
(reproductive-rights-data-project-py3.11) michaelp@MacBook-Air-3 reproductive-rights-data-project % python ./ --api --parse-data --visualize
We are gonna do some API work
We are gonna do some data parsing work
We are gonna do some visualizations
```

- [x] Manual testing of flags from `Makefile`

```
(reproductive-rights-data-project-py3.11) michaelp@MacBook-Air-3 reproductive-rights-data-project % make api
python ./ --api
We are gonna do some API work
(reproductive-rights-data-project-py3.11) michaelp@MacBook-Air-3 reproductive-rights-data-project % make parse-data
python ./ --parse-data
We are gonna do some data parsing work
(reproductive-rights-data-project-py3.11) michaelp@MacBook-Air-3 reproductive-rights-data-project % make visualize 
python ./ --visualize
We are gonna do some visualizations
```
