### PR TITLE
Added lint command reference to README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ test-and-fail:
 
 .PHONY: lint
 lint:
-	pylint ./apis/* ./models/* ./test/* ./visualizations/*
+	pylint ./apis/ ./models/ ./test/ ./visualizations/
 
 .PHONY: api
 api:

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A capstone project for UChicago's CAPP122 where abortion related data is taken f
 
 ## Standard Commands
 - `make format`: Formats the python files within the project using the Python formatter [Black](https://github.com/psf/black)
+- `make lint`: Runs `pytlint` on the codebase
 - `make test`: Runs test cases in the `test` directory
 - `make api`: Runs the `api` portion of the codebase
 - `make parse-data`: Parses the data output of the `api` layer


### PR DESCRIPTION
## What does this pull request add?
The command for `pylint` has been added to the README

## Are there any technical things that should be noted for this PR?
Nay.

## How was it tested?
- [x] I manually tested it

```
(reproductive-rights-data-project-py3.11) michaelp@MacBook-Air-3 reproductive-rights-data-project % make lint
pylint ./apis/ ./models/ ./test/ ./visualizations/
************* Module reproductive-rights-data-project.apis.abortion_policy_api
apis/abortion_policy_api.py:1:0: C0114: Missing module docstring (missing-module-docstring)
apis/abortion_policy_api.py:21:9: W1514: Using open without explicitly specifying an encoding (unspecified-encoding)
apis/abortion_policy_api.py:48:20: W3101: Missing timeout argument for method 'requests.get' can cause your program to hang indefinitely (missing-timeout)
apis/abortion_policy_api.py:49:18: W3101: Missing timeout argument for method 'requests.get' can cause your program to hang indefinitely (missing-timeout)
apis/abortion_policy_api.py:50:15: W3101: Missing timeout argument for method 'requests.get' can cause your program to hang indefinitely (missing-timeout)
apis/abortion_policy_api.py:51:16: W3101: Missing timeout argument for method 'requests.get' can cause your program to hang indefinitely (missing-timeout)
apis/abortion_policy_api.py:81:9: W1514: Using open without explicitly specifying an encoding (unspecified-encoding)
apis/abortion_policy_api.py:88:9: W1514: Using open without explicitly specifying an encoding (unspecified-encoding)
apis/abortion_policy_api.py:91:9: W1514: Using open without explicitly specifying an encoding (unspecified-encoding)
apis/abortion_policy_api.py:94:9: W1514: Using open without explicitly specifying an encoding (unspecified-encoding)
apis/abortion_policy_api.py:97:9: W1514: Using open without explicitly specifying an encoding (unspecified-encoding)
apis/abortion_policy_api.py:101:21: W0613: Unused argument 'g' (unused-argument)
apis/abortion_policy_api.py:101:24: W0613: Unused argument 'i' (unused-argument)
apis/abortion_policy_api.py:101:27: W0613: Unused argument 'm' (unused-argument)
apis/abortion_policy_api.py:101:30: W0613: Unused argument 'w' (unused-argument)

-----------------------------------
Your code has been rated at 6.67/10

make: *** [lint] Error 20

```
