### PR TITLE
Add util folder to Makefile

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,5 +7,9 @@
 ## How was it tested?
 - [ ] Wrote test cases.
 - [ ] Previously working test cases are still passing.
+
+```
+PUT THE `make test` OUTPUT HERE
+```
 - [ ] I ran `pylint` and have made the bulk of changes that it has requested.
 - [ ] I ran the `black` formatter and pushed the changes.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Author(s): Michael Plunkett
 .PHONY: format
 format:
-	black ./__main__.py ./api/ ./test/ ./visualization/ ./data_handling/ --line-length=80
+	black ./__main__.py ./api/ ./test/ ./visualization/ ./data_handling/ ./util --line-length=80
 
 .PHONY: test
 test:
@@ -13,7 +13,7 @@ test-and-fail:
 
 .PHONY: lint
 lint:
-	pylint ./api/ ./test/ ./visualization/ ./data_handling/
+	pylint ./api/ ./test/ ./visualization/ ./data_handling/ ./util
 
 .PHONY: api
 api:


### PR DESCRIPTION
## What does this pull request add?
The `util` folder was missing from the `format` and `lint` commands. Done updated that omission.

## Are there any technical things that should be noted for this PR?
Nay.

## How was it tested?
- [x] Previously working test cases are still passing.

```
(reproductive-rights-data-project-py3.11) michaelp@MacBook-Air-3 reproductive-rights-data-project % make test
pytest -vs ./test/
============================================================================ test session starts =============================================================================
platform darwin -- Python 3.11.1, pytest-7.2.1, pluggy-1.0.0 -- /Users/michaelp/Documents/GitHub/reproductive-rights-data-project/.venv/bin/python
cachedir: .pytest_cache
rootdir: /Users/michaelp/Documents/GitHub/reproductive-rights-data-project
collected 12 items                                                                                                                                                           

test/test_api.py::test_get_api_data PASSED
test/test_api.py::test_to_json Writing out to json file
PASSED
test/test_api.py::test_set_default_types PASSED
test/test_api.py::test_fill_in_missing_data PASSED
test/test_api.py::test_add_missing_states PASSED
test/test_data_handling.py::test_make_row_dicts PASSED
test/test_data_handling.py::test_set_default_types PASSED
test/test_data_handling.py::test_clean_ansirh PASSED
test/test_data_handling.py::test_translate_code_to_state PASSED
test/test_data_handling.py::test_split_by_state PASSED
test/test_data_handling.py::test_split_by_zip PASSED
test/test_data_handling.py::test_to_json PASSED

============================================================================= 12 passed in 3.28s =============================================================================
(reproductive-rights-data-project-py3.11) michaelp@MacBook-Air-3 reproductive-rights-data-project % 
```
- [x] I ran `pylint` and have made the bulk of changes that it has requested.
- [x] I ran the `black` formatter and pushed the changes.
